### PR TITLE
feat(homebrew): add support for Brewfile management, formula pinning,…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,6 @@ To tap into new Github repositories, simply use the tap provider:
       provider => tap,
     }
 
-You can untap a repository by setting ensure to ``absent``.
-
 Ordering Taps
 ^^^^^^^^^^^^^
 
@@ -77,9 +75,76 @@ or by setting all taps to occur before all other usages of this package with
 .. code-block:: puppet
 
     # pick whichever provider(s) are relevant
-    Package <| provider == tap |> -> Package <| provider == homebrew |>
-    Package <| provider == tap |> -> Package <| provider == brew |>
-    Package <| provider == tap |> -> Package <| provider == brewcask |>
+    Homebrew_tap <| |> -> Package <| provider == homebrew |>
+    Homebrew_tap <| |> -> Package <| provider == brew |>
+    Homebrew_tap <| |> -> Package <| provider == brewcask |>
+
+Pinning Formulae
+~~~~~~~~~~~~~~~~~
+
+Pin an installed formula so ``brew upgrade`` leaves it untouched, using the
+native ``homebrew_pin`` type. The formula must already be installed:
+
+.. code-block:: puppet
+
+    package { 'postgresql@14':
+      ensure   => present,
+      provider => brew,
+    }
+    -> homebrew_pin { 'postgresql@14':
+      ensure => present,
+    }
+
+Set ``ensure => absent`` to unpin.
+
+Managing Services
+~~~~~~~~~~~~~~~~~
+
+Manage ``brew services`` background daemons with the native ``homebrew_service``
+type:
+
+.. code-block:: puppet
+
+    homebrew_service { 'postgresql@14':
+      ensure  => running,   # or 'stopped'
+      require => Package['postgresql@14'],
+    }
+
+Applying a Brewfile
+~~~~~~~~~~~~~~~~~~~
+
+Apply a ``Brewfile`` declaratively with ``homebrew_bundle``. Idempotence is
+delegated to ``brew bundle check``:
+
+.. code-block:: puppet
+
+    homebrew_bundle { '/Users/kevin/Brewfile':
+      ensure => present,
+    }
+
+    # named form with an explicit path and pruning of unlisted packages
+    homebrew_bundle { 'company-baseline':
+      ensure  => present,
+      path    => '/etc/homebrew/Brewfile',
+      cleanup => true,
+    }
+
+Extra Environment Variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Besides ``github_token`` (which sets ``HOMEBREW_GITHUB_API_TOKEN``), arbitrary
+``HOMEBREW_*`` variables can be written to ``/etc/environment`` via the
+``homebrew_environment`` hash:
+
+.. code-block:: puppet
+
+    class { 'homebrew':
+      user                 => 'kevin',
+      homebrew_environment => {
+        'HOMEBREW_NO_AUTO_UPDATE' => '1',
+        'HOMEBREW_NO_ANALYTICS'   => '1',
+      },
+    }
 
 Installing Brew
 ~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -113,8 +113,6 @@ compatibility but is deprecated in favour of ``homebrew_tap``:
       provider => tap,
     }
 
-You can untap a repository by setting ensure to ``absent``.
-
 Ordering Taps
 ^^^^^^^^^^^^^
 
@@ -142,6 +140,55 @@ or by setting all taps to occur before all other usages of this package with
     Homebrew_tap <| |> -> Package <| provider == brew |>
     Homebrew_tap <| |> -> Package <| provider == brewcask |>
 
+Pinning Formulae
+~~~~~~~~~~~~~~~~~
+
+Pin an installed formula so ``brew upgrade`` leaves it untouched, using the
+native ``homebrew_pin`` type. The formula must already be installed:
+
+.. code-block:: puppet
+
+    package { 'postgresql@14':
+      ensure   => present,
+      provider => brew,
+    }
+    -> homebrew_pin { 'postgresql@14':
+      ensure => present,
+    }
+
+Set ``ensure => absent`` to unpin.
+
+Managing Services
+~~~~~~~~~~~~~~~~~
+
+Manage ``brew services`` background daemons with the native ``homebrew_service``
+type:
+
+.. code-block:: puppet
+
+    homebrew_service { 'postgresql@14':
+      ensure  => running,   # or 'stopped'
+      require => Package['postgresql@14'],
+    }
+
+Applying a Brewfile
+~~~~~~~~~~~~~~~~~~~
+
+Apply a ``Brewfile`` declaratively with ``homebrew_bundle``. Idempotence is
+delegated to ``brew bundle check``:
+
+.. code-block:: puppet
+
+    homebrew_bundle { '/Users/kevin/Brewfile':
+      ensure => present,
+    }
+
+    # named form with an explicit path and pruning of unlisted packages
+    homebrew_bundle { 'company-baseline':
+      ensure  => present,
+      path    => '/etc/homebrew/Brewfile',
+      cleanup => true,
+    }
 
 Extra Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/puppet/provider/homebrew_bundle/brew.rb
+++ b/lib/puppet/provider/homebrew_bundle/brew.rb
@@ -1,0 +1,48 @@
+require 'puppet_x/homebrew/brew_command'
+
+Puppet::Type.type(:homebrew_bundle).provide(:brew) do
+  desc 'Applies a Brewfile using `brew bundle` on macOS.'
+
+  extend PuppetX::Homebrew::BrewCommand
+
+  confine :operatingsystem => :darwin
+  defaultfor :operatingsystem => :darwin
+
+  @brewbin = detect_brew_bin
+
+  commands :brew => @brewbin
+  commands :stat => '/usr/bin/stat'
+
+  def run_brew(*args)
+    self.class.run_brew(*args)
+  end
+
+  def brewfile
+    resource.brewfile
+  end
+
+  # `brew bundle check` exits non-zero when the Brewfile is not satisfied.
+  def exists?
+    run_brew('bundle', 'check', "--file=#{brewfile}")
+    true
+  rescue Puppet::ExecutionFailure
+    false
+  end
+
+  def create
+    Puppet.debug("Installing Brewfile #{brewfile}")
+    run_brew('bundle', 'install', "--file=#{brewfile}")
+    cleanup if resource[:cleanup] == :true
+  rescue Puppet::ExecutionFailure => e
+    raise Puppet::Error, "Could not apply Brewfile #{brewfile}: #{e}"
+  end
+
+  private
+
+  def cleanup
+    Puppet.debug("Cleaning up packages not in #{brewfile}")
+    run_brew('bundle', 'cleanup', '--force', "--file=#{brewfile}")
+  rescue Puppet::ExecutionFailure => e
+    raise Puppet::Error, "Could not clean up Brewfile #{brewfile}: #{e}"
+  end
+end

--- a/lib/puppet/provider/homebrew_pin/brew.rb
+++ b/lib/puppet/provider/homebrew_pin/brew.rb
@@ -1,0 +1,86 @@
+require 'puppet_x/homebrew/brew_command'
+
+Puppet::Type.type(:homebrew_pin).provide(:brew) do
+  desc 'Pins/unpins Homebrew formulae using `brew pin` / `brew unpin` on macOS.'
+
+  extend PuppetX::Homebrew::BrewCommand
+
+  confine :operatingsystem => :darwin
+  defaultfor :operatingsystem => :darwin
+
+  @brewbin = detect_brew_bin
+
+  commands :brew => @brewbin
+  commands :stat => '/usr/bin/stat'
+
+  def run_brew(*args)
+    self.class.run_brew(*args)
+  end
+
+  # `brew list --pinned` prints one pinned formula name per line.
+  def self.pinned_formulae
+    output = run_brew('list', '--pinned')
+    output.to_s.split("\n").map { |line| line.strip.downcase }.reject(&:empty?)
+  rescue StandardError => e
+    Puppet.debug("Could not read pinned homebrew formulae: #{e}")
+    []
+  end
+
+  def self.instances
+    pinned_formulae.map do |name|
+      new(:name => name, :ensure => :present)
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |provider|
+      if (resource = resources[provider.name])
+        resource.provider = provider
+      end
+    end
+  end
+
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def flush
+    if @property_flush[:ensure] == :absent
+      unpin
+    elsif @property_flush[:ensure] == :present
+      pin
+    end
+
+    @property_hash = { :name => resource[:name], :ensure => @property_flush[:ensure] || :absent }
+    @property_flush = {}
+  end
+
+  private
+
+  def pin
+    Puppet.debug("Pinning #{resource[:name]}")
+    run_brew('pin', resource[:name])
+  rescue Puppet::ExecutionFailure => e
+    raise Puppet::Error, "Could not pin #{resource[:name]}: #{e}"
+  end
+
+  def unpin
+    Puppet.debug("Unpinning #{resource[:name]}")
+    run_brew('unpin', resource[:name])
+  rescue Puppet::ExecutionFailure => e
+    raise Puppet::Error, "Could not unpin #{resource[:name]}: #{e}"
+  end
+end

--- a/lib/puppet/provider/homebrew_service/brew.rb
+++ b/lib/puppet/provider/homebrew_service/brew.rb
@@ -1,0 +1,72 @@
+require 'json'
+require 'puppet_x/homebrew/brew_command'
+
+Puppet::Type.type(:homebrew_service).provide(:brew) do
+  desc 'Manages Homebrew services using `brew services` on macOS.'
+
+  extend PuppetX::Homebrew::BrewCommand
+
+  confine :operatingsystem => :darwin
+  defaultfor :operatingsystem => :darwin
+
+  @brewbin = detect_brew_bin
+
+  commands :brew => @brewbin
+  commands :stat => '/usr/bin/stat'
+
+  def run_brew(*args)
+    self.class.run_brew(*args)
+  end
+
+  # `brew services list --json` returns an array of objects exposing the
+  # service `name` and `status` (started/stopped/none/error/scheduled).
+  def self.service_list
+    output = run_brew('services', 'list', '--json')
+    JSON.parse(output)
+  rescue StandardError => e
+    Puppet.debug("Could not read homebrew services: #{e}")
+    []
+  end
+
+  def self.instances
+    service_list.map do |svc|
+      new(
+        :name   => svc['name'].to_s.downcase,
+        :ensure => svc['status'].to_s == 'started' ? :running : :stopped,
+      )
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |provider|
+      if (resource = resources[provider.name])
+        resource.provider = provider
+      end
+    end
+  end
+
+  def initialize(value = {})
+    super(value)
+    @property_hash = value.dup
+  end
+
+  def status
+    @property_hash[:ensure] || :stopped
+  end
+
+  def start
+    Puppet.debug("Starting brew service #{resource[:name]}")
+    run_brew('services', 'start', resource[:name])
+    @property_hash[:ensure] = :running
+  rescue Puppet::ExecutionFailure => e
+    raise Puppet::Error, "Could not start service #{resource[:name]}: #{e}"
+  end
+
+  def stop
+    Puppet.debug("Stopping brew service #{resource[:name]}")
+    run_brew('services', 'stop', resource[:name])
+    @property_hash[:ensure] = :stopped
+  rescue Puppet::ExecutionFailure => e
+    raise Puppet::Error, "Could not stop service #{resource[:name]}: #{e}"
+  end
+end

--- a/lib/puppet/type/homebrew_bundle.rb
+++ b/lib/puppet/type/homebrew_bundle.rb
@@ -1,0 +1,50 @@
+Puppet::Type.newtype(:homebrew_bundle) do
+  @doc = <<-DOC
+    Applies a Homebrew `Brewfile` via `brew bundle`.
+
+    Idempotence is delegated to `brew bundle check`: when the Brewfile's
+    dependencies are already satisfied the resource is in sync, otherwise
+    `brew bundle install` runs. Optionally, `cleanup` removes anything not
+    listed in the Brewfile.
+
+    @example Apply a Brewfile
+      homebrew_bundle { '/Users/admin/Brewfile':
+        ensure => present,
+      }
+
+    @example Apply and prune extras
+      homebrew_bundle { 'company-baseline':
+        ensure  => present,
+        path    => '/etc/homebrew/Brewfile',
+        cleanup => true,
+      }
+  DOC
+
+  ensurable do
+    desc 'Whether the Brewfile should be applied (`present`).'
+    defaultto :present
+
+    newvalue(:present) do
+      provider.create
+    end
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary identifier, or the Brewfile path when `path` is unset.'
+  end
+
+  newparam(:path) do
+    desc 'Path to the Brewfile. Defaults to the resource name.'
+  end
+
+  newparam(:cleanup, :boolean => true) do
+    desc 'Whether to run `brew bundle cleanup --force` after install.'
+    newvalues(:true, :false)
+    defaultto :false
+  end
+
+  # Allow `homebrew_bundle { '/path/to/Brewfile': }` shorthand.
+  def brewfile
+    self[:path] || self[:name]
+  end
+end

--- a/lib/puppet/type/homebrew_pin.rb
+++ b/lib/puppet/type/homebrew_pin.rb
@@ -1,0 +1,25 @@
+Puppet::Type.newtype(:homebrew_pin) do
+  @doc = <<-DOC
+    Pins a Homebrew formula so that `brew upgrade` will not update it.
+
+    Wraps `brew pin` / `brew unpin`. The formula must already be installed for
+    Homebrew to pin it; manage the `package` resource first and let this pin
+    depend on it.
+
+    @example Pin an installed formula
+      homebrew_pin { 'postgresql@14':
+        ensure => present,
+      }
+  DOC
+
+  ensurable do
+    desc 'Whether the formula should be pinned (`present`) or unpinned (`absent`).'
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'The name of an installed formula to pin (e.g. postgresql@14).'
+
+    munge(&:downcase)
+  end
+end

--- a/lib/puppet/type/homebrew_service.rb
+++ b/lib/puppet/type/homebrew_service.rb
@@ -1,0 +1,43 @@
+Puppet::Type.newtype(:homebrew_service) do
+  @doc = <<-DOC
+    Manages background services registered with `brew services` on macOS.
+
+    Wraps `brew services start` / `brew services stop`. The formula providing
+    the service must already be installed; manage the `package` resource first
+    and let this service depend on it.
+
+    @example Keep a service running
+      homebrew_service { 'postgresql@14':
+        ensure => running,
+      }
+
+    @example Stop a service
+      homebrew_service { 'redis':
+        ensure => stopped,
+      }
+  DOC
+
+  ensurable do
+    desc 'Whether the service should be `running` or `stopped`.'
+
+    newvalue(:running) do
+      provider.start
+    end
+
+    newvalue(:stopped) do
+      provider.stop
+    end
+
+    defaultto :running
+
+    def retrieve
+      provider.status
+    end
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'The name of an installed formula that provides a brew service.'
+
+    munge(&:downcase)
+  end
+end

--- a/tests/homebrew_bundle.pp
+++ b/tests/homebrew_bundle.pp
@@ -1,0 +1,11 @@
+# Apply a Brewfile. The shorthand form uses the resource name as the path.
+homebrew_bundle { '/Users/travis/Brewfile':
+  ensure => present,
+}
+
+# Named form with an explicit path and cleanup of unlisted packages.
+homebrew_bundle { 'company-baseline':
+  ensure  => present,
+  path    => '/etc/homebrew/Brewfile',
+  cleanup => true,
+}

--- a/tests/homebrew_pin.pp
+++ b/tests/homebrew_pin.pp
@@ -1,0 +1,15 @@
+# Pin an installed formula so `brew upgrade` leaves it alone.
+package { 'postgresql@14':
+  ensure   => present,
+  provider => brew,
+}
+
+homebrew_pin { 'postgresql@14':
+  ensure  => present,
+  require => Package['postgresql@14'],
+}
+
+# Explicitly unpin another formula.
+homebrew_pin { 'openssl@3':
+  ensure => absent,
+}

--- a/tests/homebrew_service.pp
+++ b/tests/homebrew_service.pp
@@ -1,0 +1,15 @@
+# Install a formula and keep its brew service running.
+package { 'postgresql@14':
+  ensure   => present,
+  provider => brew,
+}
+
+homebrew_service { 'postgresql@14':
+  ensure  => running,
+  require => Package['postgresql@14'],
+}
+
+# Ensure another service stays stopped.
+homebrew_service { 'redis':
+  ensure => stopped,
+}


### PR DESCRIPTION
… and service management

- Introduced `homebrew_bundle` type for applying Brewfiles.
- Added `homebrew_pin` type to pin/unpin Homebrew formulae.
- Implemented `homebrew_service` type for managing Homebrew services.
- Updated README with usage examples for new features.