### PR TITLE
feat(homebrew): add Homebrew tap update management

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,41 @@ or by setting all taps to occur before all other usages of this package with
     Homebrew_tap <| |> -> Package <| provider == brew |>
     Homebrew_tap <| |> -> Package <| provider == brewcask |>
 
+Updating Taps
+~~~~~~~~~~~~~
+
+Homebrew only auto-updates taps just before a ``brew install``/``upgrade``/``tap``
+runs, and this module deliberately sets ``HOMEBREW_NO_AUTO_UPDATE=1`` on all of
+its provider reads. On a converged machine where nothing is installed during a
+run, the taps would therefore never be refreshed.
+
+Enable ``manage_update`` to run ``brew update`` (which fetches every git tap,
+official *and* third-party) in a dedicated, opt-in class. The run is guarded by a
+timestamp marker so it fires **at most once per interval** — between intervals
+the resource stays ``unchanged``, so there is no per-run ``changed`` churn:
+
+.. code-block:: puppet
+
+    class { 'homebrew':
+      user             => 'homebrew',
+      manage_update    => true,
+      update_frequency => 86400,   # seconds; default is 24h
+    }
+
+The marker (``<brew_prefix>/var/homebrew/.puppet-last-brew-update``) is only
+refreshed on a successful ``brew update``, so a transient (e.g. network) failure
+is retried on the next run rather than silently skipped for the whole interval.
+
+To guarantee taps are refreshed before your packages are (re)installed, order the
+class ahead of the ``brew`` packages in your own profile:
+
+.. code-block:: puppet
+
+    Class['homebrew::update'] -> Package <| provider == brew |>
+
+``manage_update`` defaults to ``false``; when left disabled the ``homebrew::update``
+class is not declared and behaviour is unchanged.
+
 Pinning Formulae
 ~~~~~~~~~~~~~~~~~
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@ class homebrew (
   $group                      = 'admin',
   $multiuser                  = false,
   Boolean $manage_update      = false,
-  Integer $update_frequency   = 86400,
+  Integer[60] $update_frequency   = 86400,
   Hash[String, String] $homebrew_environment = {},
 ) {
   if $facts['os']['name'] != 'Darwin' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,8 @@ class homebrew (
   $github_token               = undef,
   $group                      = 'admin',
   $multiuser                  = false,
+  Boolean $manage_update      = false,
+  Integer $update_frequency   = 86400,
   Hash[String, String] $homebrew_environment = {},
 ) {
   if $facts['os']['name'] != 'Darwin' {
@@ -20,6 +22,12 @@ class homebrew (
 
   contain 'homebrew::compiler'
   contain 'homebrew::install'
+
+  if $manage_update {
+    class { 'homebrew::update': }
+    contain 'homebrew::update'
+    Class['homebrew::install'] -> Class['homebrew::update']
+  }
 
   # HOMEBREW_GITHUB_API_TOKEN keeps its dedicated parameter for backwards
   # compatibility; any additional HOMEBREW_* variable can be set through the

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,0 +1,25 @@
+class homebrew::update {
+  # Homebrew prefix depends on architecture (same logic as homebrew::install).
+  if $facts['is_arm64'] {
+    $brew_root = '/opt/homebrew'
+  } else {
+    $brew_root = '/usr/local'
+  }
+
+  $brew   = "${brew_root}/bin/brew"
+  $marker = "${brew_root}/var/homebrew/.puppet-last-brew-update"
+
+  # $update_frequency is expressed in seconds; find -mmin works in minutes.
+  $frequency_minutes = $homebrew::update_frequency / 60
+
+  # Refresh every git tap (official + third-party) at most once per interval.
+  # The marker is only touched on success (&&), so a transient failure does not
+  # freeze the interval and is retried on the next run. Between intervals the
+  # `unless` guard skips the exec, so the resource stays unchanged (no churn).
+  exec { 'homebrew-update':
+    command   => "/usr/bin/su ${homebrew::user} -c '${brew} update' && /usr/bin/touch ${marker}",
+    unless    => "/usr/bin/find ${marker} -mmin -${frequency_minutes} | /usr/bin/grep -q .",
+    logoutput => on_failure,
+    timeout   => 0,
+  }
+}

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,10 +1,7 @@
 class homebrew::update {
-  # Homebrew prefix depends on architecture (same logic as homebrew::install).
-  if $facts['is_arm64'] {
-    $brew_root = '/opt/homebrew'
-  } else {
-    $brew_root = '/usr/local'
-  }
+  # Reuse the architecture-dependent prefix computed by homebrew::install rather
+  # than recomputing it (init.pp evaluates install before declaring this class).
+  $brew_root = $homebrew::install::brew_root
 
   $brew   = "${brew_root}/bin/brew"
   $marker = "${brew_root}/var/homebrew/.puppet-last-brew-update"
@@ -13,13 +10,14 @@ class homebrew::update {
   $frequency_minutes = $homebrew::update_frequency / 60
 
   # Refresh every git tap (official + third-party) at most once per interval.
-  # The marker is only touched on success (&&), so a transient failure does not
-  # freeze the interval and is retried on the next run. Between intervals the
-  # `unless` guard skips the exec, so the resource stays unchanged (no churn).
+  # The marker is only touched on success (&&), so a transient failure leaves it
+  # untouched and is retried on the next run; `|| true` swallows that failure so
+  # a network blip is not reported as a failed Puppet resource. Between intervals
+  # the `unless` guard skips the exec, so the resource stays unchanged (no churn).
   exec { 'homebrew-update':
-    command   => "/usr/bin/su ${homebrew::user} -c '${brew} update' && /usr/bin/touch ${marker}",
+    command   => "/usr/bin/su ${homebrew::user} -c '(${brew} update && /usr/bin/touch ${marker}) || true'",
     unless    => "/usr/bin/find ${marker} -mmin -${frequency_minutes} | /usr/bin/grep -q .",
     logoutput => on_failure,
-    timeout   => 0,
+    timeout   => 300,
   }
 }

--- a/tests/update.pp
+++ b/tests/update.pp
@@ -1,0 +1,6 @@
+class { 'homebrew':
+  user             => 'travis',
+  group            => 'admin',
+  manage_update    => true,
+  update_frequency => 86400,
+}


### PR DESCRIPTION
- Introduced `manage_update` parameter to control Homebrew tap updates.
- Added `homebrew::update` class to handle periodic updates with a configurable frequency.
- Updated README with instructions on enabling and configuring tap updates.
- Ensured transient failures during updates are retried without affecting the update interval.